### PR TITLE
fix spelling in male handball and female softball

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -1892,7 +1892,7 @@
                     },
                     {
                         "country_id": "slo",
-                        "manager_name": "Uroš Aorman",
+                        "manager_name": "Uroš Zorman",
                         "manager_sex": "male",
                         "result": 10
                     },
@@ -1993,7 +1993,7 @@
                         "result": 6
                     },
                     {
-                        "country_id": "CRO",
+                        "country_id": "cro",
                         "manager_name": "Hrvoje Horvat",
                         "manager_sex": "male",
                         "result": 9
@@ -2081,7 +2081,7 @@
                     },
                     {
                         "country_id": "can",
-                        "manager_name": "Kalegh Rafter",
+                        "manager_name": "Kaleigh Rafter",
                         "manager_sex": "female",
                         "result": 6
                     },


### PR DESCRIPTION
[Male's Handball Squads](https://en.wikipedia.org/wiki/2023_World_Men%27s_Handball_Championship_squads)
[Male's Handball Final ranking](https://en.wikipedia.org/wiki/2023_World_Men%27s_Handball_Championship#Final_ranking)
[Female's Softball Squads and final standings](https://www.wbsc.org/en/events/2022-world-games-womens-softball/home)